### PR TITLE
[Core] Use format.

### DIFF
--- a/svg/templatetags/svg.py
+++ b/svg/templatetags/svg.py
@@ -25,14 +25,17 @@ def svg(filename):
 
     if SVG_DIRS:
         for directory in SVG_DIRS:
-            svg_path = os.path.join(directory, '%s.svg' % filename)
+            svg_path = os.path.join(directory, '{filename}.svg'.format(
+                filename=filename))
+
             if os.path.isfile(svg_path):
                 path = svg_path
     else:
-        path = finders.find(os.path.join('svg', '%s.svg' % filename), all=True)
+        path = finders.find(os.path.join('svg', '{filename}.svg'.format(
+            filename=filename)), all=True)
 
     if not path:
-        message = "SVG '%s.svg' not found" % filename
+        message = "SVG '{filename}.svg' not found".format(filename=filename)
 
         # Raise exception if DEBUG is True, else just log a warning.
         if settings.DEBUG:


### PR DESCRIPTION
The formatting with modulo are obsolete and may go away in the future
versions of python. It's better to use format.