### PR TITLE
Adds support for passing html attributes to svg templatetag

### DIFF
--- a/svg/templatetags/svg.py
+++ b/svg/templatetags/svg.py
@@ -15,7 +15,7 @@ register = template.Library()
 
 
 @register.simple_tag
-def svg(filename):
+def svg(filename, *args, **kwargs):
     SVG_DIRS = getattr(settings, 'SVG_DIRS', [])
 
     if type(SVG_DIRS) != list:
@@ -49,6 +49,12 @@ def svg(filename):
         path = path[0]
 
     with open(path) as svg_file:
-        svg = mark_safe(svg_file.read())
+        svg = svg_file.read()
+
+    if kwargs:
+        attributes = " ".join(["{}=\"{}\"".format(k, v) for k, v in kwargs.items()])
+        svg = svg.replace('<svg', '<svg ' + attributes)
+
+    svg = mark_safe(svg)
 
     return svg

--- a/svg/tests.py
+++ b/svg/tests.py
@@ -18,6 +18,17 @@ class SVGTemplateTagTest(SimpleTestCase):
 
         self.assertEqual(svg_file, template.render(Context()))
 
+    def test_should_support_attributes(self):
+        svg_file = open(os.path.join(settings.BASE_DIR,
+                                     'static',
+                                     'svg',
+                                     'django.svg')).read()
+        template = Template("{% load svg %}{% svg 'django' id='logo' class='large' %}")
+
+        self.assertNotEqual(svg_file, template.render(Context()))
+        self.assertIn('id="logo"', template.render(Context()))
+        self.assertIn('class="large"', template.render(Context()))
+
     def test_when_given_invalid_file_it_should_fail_silently(self):
         template = Template("{% load svg %}{% svg 'thisdoesntexist' %}")
 


### PR DESCRIPTION
With inlining SVG's it's often useful to give them class names to support things like using CSS to change fill color. Another really useful approach is when using a framework like tailwind, that uses utility classes to be able to just say:

`{% svg 'icon-search' class='h-10 mt-6' %}`

and this will add fixed height and top margin to SVG.

This PR adds the ability to add extra attributes to the templatag.

This change is inspired by Log1x/sage-svg, that makes it really easy to use this pattern in Laravel Blade nad Sage Wordpress theme.